### PR TITLE
Conform Vapor.Abort to OpenAPIRuntime.HTTPResponseConvertible

### DIFF
--- a/Sources/OpenAPIVapor/AbortExtensions.swift
+++ b/Sources/OpenAPIVapor/AbortExtensions.swift
@@ -35,19 +35,21 @@ extension Abort: @retroactive HTTPResponseConvertible {
       title: "\(identifier): \(reason)",
       status: Int(status.code)
     )
-    guard let data = try? jsonEncoder.encode(problem) else {
+    guard let encoder = try? ContentConfiguration.global.requireEncoder(for: .json) else {
+      // We don't have a great place to communicate a missing encoder here.
+      return nil
+    }
+    var buffer = ByteBuffer()
+    var headers = HTTPHeaders()
+    do {
+      try encoder.encode(problem, to: &buffer, headers: &headers)
+    } catch {
       // We don't have a great place to communicate an encoding error here.
       return nil
     }
-    return .init(data)
+    return .init(buffer.readableBytesView)
   }
 }
-
-private let jsonEncoder: JSONEncoder = {
-  let encoder = JSONEncoder()
-  encoder.outputFormatting = [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes]
-  return encoder
-}()
 
 // https://datatracker.ietf.org/doc/html/rfc7807#section-3.1
 private struct JSONProblem: Encodable {

--- a/Sources/OpenAPIVapor/AbortExtensions.swift
+++ b/Sources/OpenAPIVapor/AbortExtensions.swift
@@ -35,14 +35,14 @@ extension Abort: @retroactive HTTPResponseConvertible {
       title: "\(identifier): \(reason)",
       status: Int(status.code)
     )
-    guard let encoder = try? ContentConfiguration.global.requireEncoder(for: .json) else {
-      // We don't have a great place to communicate a missing encoder here.
-      return nil
-    }
     var buffer = ByteBuffer()
     var headers = HTTPHeaders()
     do {
-      try encoder.encode(problem, to: &buffer, headers: &headers)
+      if let encoder = try? ContentConfiguration.global.requireEncoder(for: .json) {
+        try encoder.encode(problem, to: &buffer, headers: &headers)
+      } else {
+        try fallbackJSONEncoder.encode(problem, to: &buffer, headers: &headers)
+      }
     } catch {
       // We don't have a great place to communicate an encoding error here.
       return nil
@@ -51,11 +51,14 @@ extension Abort: @retroactive HTTPResponseConvertible {
   }
 }
 
-// https://datatracker.ietf.org/doc/html/rfc7807#section-3.1
+private let fallbackJSONEncoder: JSONEncoder = {
+  let encoder = JSONEncoder()
+  encoder.outputFormatting = [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes]
+  return encoder
+}()
+
+// A subset of https://datatracker.ietf.org/doc/html/rfc7807#section-3.1
 private struct JSONProblem: Encodable {
-  var type: URI?
-  var title: String?
-  var status: Int?
-  var detail: String?
-  var instance: URI?
+  var title: String
+  var status: Int
 }

--- a/Sources/OpenAPIVapor/AbortExtensions.swift
+++ b/Sources/OpenAPIVapor/AbortExtensions.swift
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OpenAPI Vapor open source project
+//
+// Copyright (c) 2026 the Swift OpenAPI Vapor project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Vapor
+import OpenAPIRuntime
+import HTTPTypes
+import NIOHTTPTypesHTTP1
+
+// This @retroactive conformance is okay as it assumes that Vapor v4 will never gain
+// a direct dependency on Swift OpenAPI Runtime.
+extension Abort: @retroactive HTTPResponseConvertible {
+    public var httpStatus: HTTPResponse.Status {
+        .init(code: Int(status.code))
+    }
+
+    public var httpHeaderFields: HTTPTypes.HTTPFields {
+        var headerFields: HTTPTypes.HTTPFields = .init(headers, splitCookie: false)
+        headerFields[.contentType] = "application/json"
+        return headerFields
+    }
+
+    public var httpBody: OpenAPIRuntime.HTTPBody? {
+        let problem = JSONProblem(
+            title: "\(identifier): \(reason)",
+            status: Int(status.code)
+        )
+        guard let data = try? jsonEncoder.encode(problem) else {
+            // We don't have a great place to communicate an encoding error here.
+            return nil
+        }
+        return .init(data)
+    }
+}
+
+private let jsonEncoder: JSONEncoder = {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes]
+    return encoder
+}()
+
+// https://datatracker.ietf.org/doc/html/rfc7807#section-3.1
+private struct JSONProblem: Encodable {
+    var type: URI?
+    var title: String?
+    var status: Int?
+    var detail: String?
+    var instance: URI?
+}

--- a/Sources/OpenAPIVapor/AbortExtensions.swift
+++ b/Sources/OpenAPIVapor/AbortExtensions.swift
@@ -11,49 +11,49 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Vapor
-import OpenAPIRuntime
 import HTTPTypes
 import NIOHTTPTypesHTTP1
+import OpenAPIRuntime
+import Vapor
 
 // This @retroactive conformance is okay as it assumes that Vapor v4 will never gain
 // a direct dependency on Swift OpenAPI Runtime.
 // swift-format-ignore: AvoidRetroactiveConformances
 extension Abort: @retroactive HTTPResponseConvertible {
-    public var httpStatus: HTTPResponse.Status {
-        .init(code: Int(status.code))
-    }
+  public var httpStatus: HTTPResponse.Status {
+    .init(code: Int(status.code))
+  }
 
-    public var httpHeaderFields: HTTPTypes.HTTPFields {
-        var headerFields: HTTPTypes.HTTPFields = .init(headers, splitCookie: false)
-        headerFields[.contentType] = "application/json"
-        return headerFields
-    }
+  public var httpHeaderFields: HTTPTypes.HTTPFields {
+    var headerFields: HTTPTypes.HTTPFields = .init(headers, splitCookie: false)
+    headerFields[.contentType] = "application/json"
+    return headerFields
+  }
 
-    public var httpBody: OpenAPIRuntime.HTTPBody? {
-        let problem = JSONProblem(
-            title: "\(identifier): \(reason)",
-            status: Int(status.code)
-        )
-        guard let data = try? jsonEncoder.encode(problem) else {
-            // We don't have a great place to communicate an encoding error here.
-            return nil
-        }
-        return .init(data)
+  public var httpBody: OpenAPIRuntime.HTTPBody? {
+    let problem = JSONProblem(
+      title: "\(identifier): \(reason)",
+      status: Int(status.code)
+    )
+    guard let data = try? jsonEncoder.encode(problem) else {
+      // We don't have a great place to communicate an encoding error here.
+      return nil
     }
+    return .init(data)
+  }
 }
 
 private let jsonEncoder: JSONEncoder = {
-    let encoder = JSONEncoder()
-    encoder.outputFormatting = [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes]
-    return encoder
+  let encoder = JSONEncoder()
+  encoder.outputFormatting = [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes]
+  return encoder
 }()
 
 // https://datatracker.ietf.org/doc/html/rfc7807#section-3.1
 private struct JSONProblem: Encodable {
-    var type: URI?
-    var title: String?
-    var status: Int?
-    var detail: String?
-    var instance: URI?
+  var type: URI?
+  var title: String?
+  var status: Int?
+  var detail: String?
+  var instance: URI?
 }

--- a/Sources/OpenAPIVapor/AbortExtensions.swift
+++ b/Sources/OpenAPIVapor/AbortExtensions.swift
@@ -18,6 +18,7 @@ import NIOHTTPTypesHTTP1
 
 // This @retroactive conformance is okay as it assumes that Vapor v4 will never gain
 // a direct dependency on Swift OpenAPI Runtime.
+// swift-format-ignore: AvoidRetroactiveConformances
 extension Abort: @retroactive HTTPResponseConvertible {
     public var httpStatus: HTTPResponse.Status {
         .init(code: Int(status.code))

--- a/Tests/OpenAPIVaporTests/AbortExtensionsTests.swift
+++ b/Tests/OpenAPIVaporTests/AbortExtensionsTests.swift
@@ -28,13 +28,13 @@ final class AbortExtensionsTests: XCTestCase {
       ])
     let body = try XCTUnwrap(error.httpBody)
     let bodyString = try await String(collecting: body, upTo: 1024)
+    struct ExpectedValue: Decodable, Equatable {
+      var status: Int
+      var title: String
+    }
     XCTAssertEqual(
-      bodyString,
-      """
-      {
-        "status" : 401,
-        "title" : "401: Unauthorized"
-      }
-      """)
+      try JSONDecoder().decode(ExpectedValue.self, from: Data(bodyString.utf8)),
+      ExpectedValue(status: 401, title: "401: Unauthorized")
+    )
   }
 }

--- a/Tests/OpenAPIVaporTests/AbortExtensionsTests.swift
+++ b/Tests/OpenAPIVaporTests/AbortExtensionsTests.swift
@@ -18,19 +18,23 @@ import XCTVapor
 @testable import OpenAPIVapor
 
 final class AbortExtensionsTests: XCTestCase {
-    func testConversion() async throws {
-        let error = Abort(.unauthorized) as any HTTPResponseConvertible
-        XCTAssertEqual(error.httpStatus, .unauthorized)
-        XCTAssertEqual(error.httpHeaderFields, [
-            .contentType: "application/json"
-        ])
-        let body = try XCTUnwrap(error.httpBody)
-        let bodyString = try await String(collecting: body, upTo: 1024)
-        XCTAssertEqual(bodyString, """
-        {
-          "status" : 401,
-          "title" : "401: Unauthorized"
-        }
-        """)
-    }
+  func testConversion() async throws {
+    let error = Abort(.unauthorized) as any HTTPResponseConvertible
+    XCTAssertEqual(error.httpStatus, .unauthorized)
+    XCTAssertEqual(
+      error.httpHeaderFields,
+      [
+        .contentType: "application/json"
+      ])
+    let body = try XCTUnwrap(error.httpBody)
+    let bodyString = try await String(collecting: body, upTo: 1024)
+    XCTAssertEqual(
+      bodyString,
+      """
+      {
+        "status" : 401,
+        "title" : "401: Unauthorized"
+      }
+      """)
+  }
 }

--- a/Tests/OpenAPIVaporTests/AbortExtensionsTests.swift
+++ b/Tests/OpenAPIVaporTests/AbortExtensionsTests.swift
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift OpenAPI Vapor open source project
+//
+// Copyright (c) 2026 the Swift OpenAPI Vapor project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import HTTPTypes
+import OpenAPIRuntime
+import XCTVapor
+
+@testable import OpenAPIVapor
+
+final class AbortExtensionsTests: XCTestCase {
+    func testConversion() async throws {
+        let error = Abort(.unauthorized) as any HTTPResponseConvertible
+        XCTAssertEqual(error.httpStatus, .unauthorized)
+        XCTAssertEqual(error.httpHeaderFields, [
+            .contentType: "application/json"
+        ])
+        let body = try XCTUnwrap(error.httpBody)
+        let bodyString = try await String(collecting: body, upTo: 1024)
+        XCTAssertEqual(bodyString, """
+        {
+          "status" : 401,
+          "title" : "401: Unauthorized"
+        }
+        """)
+    }
+}


### PR DESCRIPTION
## Summary

Conforms `Vapor.Abort` to `OpenAPIRuntime.HTTPResponseConvertible`.

`OpenAPIRuntime.HTTPResponseConvertible` was added post-1.0 (proposal [here](https://swiftpackageindex.com/apple/swift-openapi-generator/1.13.0/documentation/swift-openapi-generator/soar-0011)) to make it easier to convert thrown errors into more appropriate responses.

This PR's conformance allows adopters who use Vapor with OpenAPI to throw `Vapor.Abort` from their middlewares/handlers/utility libraries and still get good responses if they use `OpenAPIRuntime.ErrorHandlingMiddleware`.

## Test Plan

Added a unit test.
